### PR TITLE
deprecate ::set-output

### DIFF
--- a/src/kustomize_build.sh
+++ b/src/kustomize_build.sh
@@ -56,6 +56,6 @@ ${build_output}
         echo "${build_payload}" | curl -s -S -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" --header "Content-Type: application/json" --data @- "${build_comment_url}" > /dev/null
     fi
 
-    echo ::set-output name=kustomize_build_output::${build_output}
+    echo "kustomize_build_output=${build_output}" >> $GITHUB_OUTPUT
     exit ${build_exit_code}
 }


### PR DESCRIPTION
**Details of Change**
deprecate `::set-output` based on https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

**Issue**
<!--- Is there any issue(bug/feature request) already open for this case? If yes, please link it.-->

**Test Results**
<!--- Please explain how did you test it? Attach links/screenshots if needed.-->
